### PR TITLE
Add lock and unlock actions

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -2,5 +2,7 @@ module.exports = {
   assign: require('./actions/assign'),
   comment: require('./actions/comment'),
   label: require('./actions/label'),
-  unlabel: require('./actions/unlabel')
+  lock: require('./actions/lock'),
+  unlabel: require('./actions/unlabel'),
+  unlock: require('./actions/unlock')
 };

--- a/lib/actions/lock.js
+++ b/lib/actions/lock.js
@@ -1,0 +1,7 @@
+module.exports = function (github, payload) {
+  return github.issues.lock({
+    user: payload.repository.owner.login,
+    repo: payload.repository.name,
+    number: payload.issue.number
+  });
+};

--- a/lib/actions/unlock.js
+++ b/lib/actions/unlock.js
@@ -1,0 +1,7 @@
+module.exports = function (github, payload) {
+  return github.issues.unlock({
+    user: payload.repository.owner.login,
+    repo: payload.repository.name,
+    number: payload.issue.number
+  });
+};


### PR DESCRIPTION
Given these rules:

```yml
  # Lock closed issues
  - on: issues.closed
    then:
      lock: true
  
  # Unlock reopened issues
  - on: issues.reopened
    then:
      unlock: true
```

Here it is in action:

<img width="735" alt="testing_locking_and_unlocking_ _issue__19_ _bkeepers-inc_test" src="https://cloud.githubusercontent.com/assets/173/19254382/a126671e-8f18-11e6-93b1-d1c6ad26f9f1.png">

---

This PR brings up a couple issues/concerns:

0. Some actions are _really_ simple. I'm starting to wonder if there's a more declarative way to define actions that hit the GitHub API.
0. I'm not sure how to write tests for these kinds of actions. The existing action tests (e.g. [this](https://github.com/bkeepers/PRobot/blob/e257e5e259094c2c2c44b599d12a834162e368e9/test/actions/assign.js)) just mock out the GitHub API and check that the right params are passed to it. This feels pretty silly for actions that are just calling the API and nothing else.
0. There's a lot of duplication in extracting the issue params from the payload, which can probably be moved into some helper methods.