### PR TITLE
Easy installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,21 @@ Here are some behaviors that we plan to implement:
 
 ## Installing
 
-TODO: install the hosted integration into your organization / account
+0. **[Install the demo integration](https://github.com/integration/probot-demo)** - note that this is very likely to go away at some point soon. It will suffice for experimenting for now, but it is for demo purposes only.
+0. Add @probot as a collaborator with write access on your repository.
+0. Create a `.probot.yml` file in your repository with the following contents. See [Configuring](#configuring) for more information.
 
-TODO: deploy your own bot
+        behaviors:
+          - on: issues.opened
+            then:
+              comment: >
+                Hello @{{ sender.login }}. Thanks for inviting me to your project. Read
+                more about [all the things I can help you with][config]. I can't wait to
+                get started!
+
+                [config]: https://github.com/bkeepers/PRobot/blob/master/docs/configuration.md
+
+0. Open a new issue. @probot should post a comment (you may need to refresh to see it).
 
 ## Configuring
 

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ debug('Starting');
 const github = new GitHubApi({debug: false});
 
 github.authenticate({
-  type: 'oauth',
+  type: 'token',
   token: process.env.GITHUB_TOKEN
 });
 
@@ -41,5 +41,17 @@ webhook.on('*', event => {
     );
   }
 });
+
+// Check for and accept any repository invitations
+function checkForInvites() {
+  debug('Checking for repository invites');
+  github.users.getRepoInvites({}).then(invites => {
+    invites.forEach(invite => {
+      debug('Accepting invite', invite.full_name);
+      github.users.acceptRepoInvite(invite);
+    });
+  });
+}
+setInterval(checkForInvites, Number(process.env.INVITE_CHECK_INTERVAL || 60) * 1000);
 
 console.log('Listening on http://localhost:' + PORT);

--- a/server.js
+++ b/server.js
@@ -59,7 +59,7 @@ function checkForInvites() {
       github.users.editOrganizationMembership({
         org: invite.organization.login,
         state: 'active'
-      })
+      });
     });
   });
 }

--- a/server.js
+++ b/server.js
@@ -47,11 +47,23 @@ function checkForInvites() {
   debug('Checking for repository invites');
   github.users.getRepoInvites({}).then(invites => {
     invites.forEach(invite => {
-      debug('Accepting invite', invite.full_name);
+      debug('Accepting repository invite', invite.full_name);
       github.users.acceptRepoInvite(invite);
     });
   });
+
+  debug('Checking for organization invites');
+  github.orgs.getOrganizationMemberships({state: 'pending'}).then(invites => {
+    invites.forEach(invite => {
+      debug('Accepting organization invite', invite.organization.login);
+      github.users.editOrganizationMembership({
+        org: invite.organization.login,
+        state: 'active'
+      })
+    });
+  });
 }
+checkForInvites();
 setInterval(checkForInvites, Number(process.env.INVITE_CHECK_INTERVAL || 60) * 1000);
 
 console.log('Listening on http://localhost:' + PORT);


### PR DESCRIPTION
Even thought the use of GitHub Integrations (#36) is currently blocked, the Integration can still be used as an easy way to configure webhooks. The only caveat is that you have to give the @probot user access to the repositories.

I've stood up a [demo instance](https://github.com/integration/probot-demo) that can be used for people to test out the bot. This updates the README with directions for how to install it on a repository, and will automatically accept organization or repository invites.

cc #6 