### PR TITLE
Load configuration from another file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,21 @@ Add labels
 .unassign('defunkt');
 ```
 
+## load
+
+Loads a configuration from another file.
+
+```js
+load('.github/bot/issues.js');
+load('.github/bot/releases.js');
+```
+
+You can also load configuration from another repository.
+
+```js
+load('user/repo:path.js#branch');
+```
+
 ---
 
 See [examples](examples.md) for ideas of behaviors you can implement by combining these configuration options.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ Only preform the actions if the function returns `true`. The `event` is passed a
 .filter(event => event.payload.issue.body.includes("- [ ]"))
 ```
 
-#### `comment`
+### `comment`
 
 Comments can be posted in response to any event performed on an Issue or Pull Request. Comments use [mustache](https://mustache.github.io/) for templates and can use any data from the event payload.
 
@@ -85,7 +85,7 @@ Comments can be posted in response to any event performed on an Issue or Pull Re
 .comment("Hey @{{ user.login }}, thanks for the contribution!");
 ```
 
-#### `close`
+### `close`
 
 Close an issue or pull request.
 
@@ -93,7 +93,7 @@ Close an issue or pull request.
 .close();
 ```
 
-#### `open`
+### `open`
 
 Reopen an issue or pull request.
 
@@ -101,7 +101,7 @@ Reopen an issue or pull request.
 .open();
 ```
 
-#### `lock`
+### `lock`
 
 Lock conversation on an issue or pull request.
 
@@ -109,7 +109,7 @@ Lock conversation on an issue or pull request.
 .lock();
 ```
 
-#### `unlock`
+### `unlock`
 
 Unlock conversation on an issue or pull request.
 
@@ -117,7 +117,7 @@ Unlock conversation on an issue or pull request.
 .unlock();
 ```
 
-#### `label`
+### `label`
 
 Add labels
 
@@ -125,7 +125,7 @@ Add labels
 .label('bug');
 ```
 
-#### `unlabel`
+### `unlabel`
 
 Add labels
 
@@ -133,13 +133,13 @@ Add labels
 .unlabel('needs-work').label('waiting-for-review');
 ```
 
-#### `assign`
+### `assign`
 
 ```
 .assign('hubot');
 ```
 
-#### `unassign`
+### `unassign`
 
 ```
 .unassign('defunkt');

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,19 +145,19 @@ Add labels
 .unassign('defunkt');
 ```
 
-## load
+## include
 
 Loads a configuration from another file.
 
 ```js
-load('.github/bot/issues.js');
-load('.github/bot/releases.js');
+include('.github/bot/issues.js');
+include('.github/bot/releases.js');
 ```
 
-You can also load configuration from another repository.
+You can also include configuration from another repository.
 
 ```js
-load('user/repo:path.js#branch');
+include('user/repo:path.js#branch');
 ```
 
 ---

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,11 +1,13 @@
 const debug = require('debug')('PRobot');
 const Sandbox = require('./sandbox');
 const Workflow = require('./workflow');
+const url = require('./util/github-url');
 
 module.exports = class Configuration {
   static load(context, path) {
+    const options = url(path);
     debug('Fetching %s from %s', path, context.payload.repository.full_name);
-    return context.github.repos.getContent(context.toRepo({path})).then(data => {
+    return context.github.repos.getContent(context.toRepo(options)).then(data => {
       return new Configuration(context).parse(new Buffer(data.content, 'base64').toString());
     });
   }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -3,26 +3,8 @@ const Sandbox = require('./sandbox');
 const Workflow = require('./workflow');
 
 module.exports = class Configuration {
-  // Get bot config from target repository
-  static load(github, repository) {
-    debug('Fetching .probot.js from %s', repository.full_name);
-    const parts = repository.full_name.split('/');
-    return github.repos.getContent({
-      owner: parts[0],
-      repo: parts[1],
-      path: '.probot.js'
-    }).then(data => {
-      const content = new Buffer(data.content, 'base64').toString();
-      debug('Configuration fetched', content);
-      return Configuration.parse(content);
-    });
-  }
-
-  static parse(content) {
-    return new Configuration().parse(content);
-  }
-
-  constructor() {
+  constructor(context) {
+    this.context = context;
     this.workflows = [];
 
     this.api = {
@@ -36,12 +18,19 @@ module.exports = class Configuration {
     return workflow.api;
   }
 
+  require(path) {
+    debug('Fetching %s from %s', path, this.context.payload.repository.full_name);
+    return this.context.github.repos.getContent(this.context.toRepo({path})).then(data => {
+      return this.parse(new Buffer(data.content, 'base64').toString());
+    });
+  }
+
   parse(content) {
     new Sandbox(content).execute(this.api);
     return this;
   }
 
-  execute(context) {
-    return Promise.all(this.workflows.map(w => w.execute(context)));
+  execute() {
+    return Promise.all(this.workflows.map(w => w.execute(this.context)));
   }
 };

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -3,12 +3,20 @@ const Sandbox = require('./sandbox');
 const Workflow = require('./workflow');
 
 module.exports = class Configuration {
+  static load(context, path) {
+    debug('Fetching %s from %s', path, context.payload.repository.full_name);
+    return context.github.repos.getContent(context.toRepo({path})).then(data => {
+      return new Configuration(context).parse(new Buffer(data.content, 'base64').toString());
+    });
+  }
+
   constructor(context) {
     this.context = context;
     this.workflows = [];
 
     this.api = {
-      on: this.on.bind(this)
+      on: this.on.bind(this),
+      load: this.load.bind(this)
     };
   }
 
@@ -18,11 +26,16 @@ module.exports = class Configuration {
     return workflow.api;
   }
 
-  require(path) {
-    debug('Fetching %s from %s', path, this.context.payload.repository.full_name);
-    return this.context.github.repos.getContent(this.context.toRepo({path})).then(data => {
-      return this.parse(new Buffer(data.content, 'base64').toString());
+  load(path) {
+    const load = Configuration.load(this.context, path);
+
+    this.workflows.push({
+      execute() {
+        return load.then(config => config.execute(this.context));
+      }
     });
+
+    return undefined;
   }
 
   parse(content) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -18,7 +18,7 @@ module.exports = class Configuration {
 
     this.api = {
       on: this.on.bind(this),
-      load: this.load.bind(this)
+      include: this.include.bind(this)
     };
   }
 
@@ -28,7 +28,7 @@ module.exports = class Configuration {
     return workflow.api;
   }
 
-  load(path) {
+  include(path) {
     const load = Configuration.load(this.context, path);
 
     this.workflows.push({

--- a/lib/context.js
+++ b/lib/context.js
@@ -8,15 +8,15 @@ module.exports = class Context {
   }
 
   toRepo(object) {
-    return Object.assign({}, object, {
+    return Object.assign({
       owner: this.payload.repository.owner.login,
       repo: this.payload.repository.name
-    });
+    }, object);
   }
 
   toIssue(object) {
-    return Object.assign({}, object, {
+    return Object.assign({
       number: (this.payload.issue || this.payload.pull_request || this.payload).number
-    }, this.toRepo());
+    }, this.toRepo(), object);
   }
 };

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -13,8 +13,10 @@ class Robot {
 
     if (event.payload.repository) {
       installations.auth(event.payload.installation.id).then(github => {
-        const config = new Configuration(new Context(github, event));
-        return config.require('.probot.js').then(() => config.execute());
+        const context = new Context(github, event);
+        Configuration.load(context, '.probot.js').then(config => {
+          return config.execute();
+        });
       });
     }
   }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('PRobot');
 const installations = require('./installations');
-const Context = require('./configuration');
+const Context = require('./context');
 const Configuration = require('./configuration');
 
 class Robot {
@@ -13,11 +13,8 @@ class Robot {
 
     if (event.payload.repository) {
       installations.auth(event.payload.installation.id).then(github => {
-        const context = new Context(github, event);
-
-        return Configuration.load(github, event.payload.repository).then(config => {
-          return config.execute(context);
-        });
+        const config = new Configuration(new Context(github, event));
+        return config.require('.probot.js').then(() => config.execute());
       });
     }
   }

--- a/lib/util/github-url.js
+++ b/lib/util/github-url.js
@@ -1,0 +1,7 @@
+const REGEX = /^(?:([\w-]+)\/([\w-]+):)?([^#]*)(?:#(.*))?$/;
+
+// Parses paths in the form of `owner/repo:path/to/file#ref`
+module.exports = function (url) {
+  const [, owner, repo, path, ref] = url.match(REGEX);
+  return Object.assign({path}, owner && {owner, repo}, ref && {ref});
+};

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -16,9 +16,10 @@ content.content = new Buffer(`
 `).toString('base64');
 
 describe('Configuration', () => {
-  describe('require', () => {
+  describe('load', () => {
     let github;
     let context;
+    let config;
 
     beforeEach(() => {
       github = {
@@ -27,19 +28,20 @@ describe('Configuration', () => {
         }
       };
       context = new Context(github, {payload});
+      config = new Configuration(context);
     });
 
     it('loads from the repo', () => {
-      const config = new Configuration(context);
-      return config.require('.probot.js').then(() => {
-        expect(github.repos.getContent).toHaveBeenCalledWith({
-          owner: 'bkeepers-inc',
-          repo: 'test',
-          path: '.probot.js'
-        });
-
-        expect(config.workflows.length).toEqual(2);
+      config.load('foo.js');
+      expect(github.repos.getContent).toHaveBeenCalledWith({
+        owner: 'bkeepers-inc',
+        repo: 'test',
+        path: 'foo.js'
       });
+    });
+
+    it('returns undefined', () => {
+      expect(config.load('foo.js')).toBe(undefined);
     });
   });
 });

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -16,7 +16,7 @@ content.content = new Buffer(`
 `).toString('base64');
 
 describe('Configuration', () => {
-  describe('load', () => {
+  describe('include', () => {
     let github;
     let context;
     let config;
@@ -31,8 +31,8 @@ describe('Configuration', () => {
       config = new Configuration(context);
     });
 
-    it('loads from the repo', () => {
-      config.load('foo.js');
+    it('includes from the repo', () => {
+      config.include('foo.js');
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
@@ -41,11 +41,11 @@ describe('Configuration', () => {
     });
 
     it('returns undefined', () => {
-      expect(config.load('foo.js')).toBe(undefined);
+      expect(config.include('foo.js')).toBe(undefined);
     });
 
-    it('loads from another repository', () => {
-      config.load('atom/configs:foo.js#branch');
+    it('includes from another repository', () => {
+      config.include('atom/configs:foo.js#branch');
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'atom',
         repo: 'configs',

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -43,5 +43,15 @@ describe('Configuration', () => {
     it('returns undefined', () => {
       expect(config.load('foo.js')).toBe(undefined);
     });
+
+    it('loads from another repository', () => {
+      config.load('atom/configs:foo.js#branch');
+      expect(github.repos.getContent).toHaveBeenCalledWith({
+        owner: 'atom',
+        repo: 'configs',
+        path: 'foo.js',
+        ref: 'branch'
+      });
+    });
   });
 });

--- a/test/context.js
+++ b/test/context.js
@@ -25,9 +25,9 @@ describe('Context', () => {
       });
     });
 
-    it('does not override repo attributes', () => {
+    it('overrides repo attributes', () => {
       expect(context.toRepo({owner: 'muahaha'})).toEqual({
-        owner: 'bkeepers', repo:'probot'
+        owner: 'muahaha', repo:'probot'
       });
     });
   });
@@ -43,9 +43,9 @@ describe('Context', () => {
       });
     });
 
-    it('does not override repo attributes', () => {
+    it('overrides repo attributes', () => {
       expect(context.toIssue({owner: 'muahaha', number: 5})).toEqual({
-        owner: 'bkeepers', repo:'probot', number: 4
+        owner: 'muahaha', repo:'probot', number: 5
       });
     });
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,7 +5,7 @@ const payload = require('./fixtures/webhook/comment.created.json');
 
 const createSpy = expect.createSpy;
 
-describe('dispatch', () => {
+describe('integration', () => {
   let context;
   let github;
 
@@ -21,9 +21,13 @@ describe('dispatch', () => {
     context = new Context(github, event);
   });
 
+  function configure(content) {
+    return new Configuration(context).parse(content);
+  }
+
   describe('reply to new issue with a comment', () => {
     it('posts a coment', () => {
-      const config = Configuration.parse('on("issues").comment("Hello World!")');
+      const config = configure('on("issues").comment("Hello World!")');
       return config.execute(context).then(() => {
         expect(github.issues.createComment).toHaveBeenCalled();
       });
@@ -32,7 +36,7 @@ describe('dispatch', () => {
 
   describe('reply to new issue with a comment', () => {
     it('calls the action', () => {
-      const config = Configuration.parse('on("issues.created").comment("Hello World!")');
+      const config = configure('on("issues.created").comment("Hello World!")');
 
       return config.execute(context).then(() => {
         expect(github.issues.createComment).toHaveBeenCalled();
@@ -42,7 +46,7 @@ describe('dispatch', () => {
 
   describe('on an event with a different action', () => {
     it('does not perform behavior', () => {
-      const config = Configuration.parse('on("issues.labeled").comment("Hello World!")');
+      const config = configure('on("issues.labeled").comment("Hello World!")');
 
       return config.execute(context).then(() => {
         expect(github.issues.createComment).toNotHaveBeenCalled();
@@ -59,14 +63,14 @@ describe('dispatch', () => {
     });
 
     it('calls action when condition matches', () => {
-      const config = Configuration.parse('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
       return config.execute(context).then(() => {
         expect(github.issues.edit).toHaveBeenCalled();
       });
     });
 
     it('does not call action when conditions do not match', () => {
-      const config = Configuration.parse('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
       return config.execute(context).then(() => {
         expect(github.issues.edit).toNotHaveBeenCalled();
       });

--- a/test/integration.js
+++ b/test/integration.js
@@ -77,7 +77,7 @@ describe('integration', () => {
     });
   });
 
-  describe('load', () => {
+  describe('include', () => {
     beforeEach(() => {
       const content = require('./fixtures/content/probot.json');
 
@@ -94,8 +94,8 @@ describe('integration', () => {
       context = new Context(github, event);
     });
 
-    it('loads a file in the local repository', () => {
-      configure('load(".github/triage.js");');
+    it('includes a file in the local repository', () => {
+      configure('include(".github/triage.js");');
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers-inc',
         repo: 'test',
@@ -103,8 +103,8 @@ describe('integration', () => {
       });
     });
 
-    it('executes loaded rules', done => {
-      configure('load(".github/triage.js");').execute().then(() => {
+    it('executes included rules', done => {
+      configure('include(".github/triage.js");').execute().then(() => {
         expect(github.issues.createComment).toHaveBeenCalled();
         done();
       });

--- a/test/util/github-url.js
+++ b/test/util/github-url.js
@@ -1,0 +1,18 @@
+const expect = require('expect');
+const url = require('../../lib/util/github-url');
+
+describe('github-url', () => {
+  const cases = {
+    'path.js': {path: 'path.js'},
+    'owner/repo:path.js': {owner: 'owner', repo: 'repo', path: 'path.js'},
+    'owner/repo:path/to/file.js': {owner: 'owner', repo: 'repo', path: 'path/to/file.js'},
+    'path.js#ref': {path: 'path.js', ref: 'ref'},
+    'owner/repo:path.js#ref': {owner: 'owner', repo: 'repo', path: 'path.js', ref: 'ref'}
+  };
+
+  Object.keys(cases).forEach(path => {
+    it(path, () => {
+      expect(url(path)).toEqual(cases[path]);
+    });
+  });
+});


### PR DESCRIPTION
This adds support for loading configs from other files.

- [x] Load from file in same repository
```js
include(".github/triage.js");
```
- [x] Load config from another repository
```js
include("owner/repo:path/to/file.js#ref"); 
```
- [x]  Decide on method name (~~`load`~~? ~~`require`~~? something else?) and syntax for GitHub URLs…went with `include`

Closes #40 