### PR TITLE
Add method for getting repository contents

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -18,7 +18,8 @@ module.exports = class Configuration {
 
     this.api = {
       on: this.on.bind(this),
-      include: this.include.bind(this)
+      include: this.include.bind(this),
+      contents: this.contents.bind(this)
     };
   }
 
@@ -38,6 +39,13 @@ module.exports = class Configuration {
     });
 
     return undefined;
+  }
+
+  contents(path) {
+    const options = url(path);
+    return this.context.github.repos.getContent(this.context.toRepo(options)).then(data => {
+      return new Buffer(data.content, 'base64').toString();
+    });
   }
 
   parse(content) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -42,8 +42,9 @@ module.exports = class Configuration {
   }
 
   contents(path) {
-    const options = url(path);
-    return this.context.github.repos.getContent(this.context.toRepo(options)).then(data => {
+    const options = this.context.toRepo(url(path));
+    debug('Getting contents', options);
+    return this.context.github.repos.getContent(options).then(data => {
       return new Buffer(data.content, 'base64').toString();
     });
   }

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -36,7 +36,10 @@ module.exports = class Workflow {
   proxy(fn) {
     return (...args) => {
       // Push new function on the stack that calls the plugin method with a context.
-      this.stack.push(context => fn(context, ...args));
+      this.stack.push(context => {
+        // Resolve all args before passing to plugin
+        Promise.all(args).then(args => fn(context, ...args));
+      });
 
       // Return the API to allow methods to be chained.
       return this.api;
@@ -46,7 +49,7 @@ module.exports = class Workflow {
   execute(context) {
     if (this.matches(context.event)) {
       // Reduce the stack to a chain of promises, each called with the given context
-      this.stack.reduce((promise, func) => {
+      return this.stack.reduce((promise, func) => {
         return promise.then(func.bind(func, context));
       }, Promise.resolve());
     }


### PR DESCRIPTION
This adds a `contents` function for getting contents from the repository. Contents can be passed to any plugin method and will be automatically fetched.

```js
on('issues.opened').comment(contents(".github/NEW_ISSUE_TEMPLATE.md"));

// This also supports fetching contents from another repository
on('issues.opened').comment(contents("atom/configs:.github/NEW_ISSUE_TEMPLATE.md"));
```

Later optimizations:

- Right now the contents are fetched from GitHub whether they are used or not. It should only fetch the contents when they are needed.

Closes #42