### PR TITLE
No need to invite probot as collaborator anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ PRobot is a trainable robot that responds to activity on GitHub. It's like [Hubo
 _**Heads up!** The [demo integration](https://github.com/integration/probot-demo) is for demo purposes only. It is very likely to go away at some point, so please don't use it for production purposes._
 
 0. Go to the **[demo integration](https://github.com/integration/probot-demo)**, click **Install**, and then select an organization.
-0. Add @probot as a collaborator with write access on your repository.
 0. Create a `.probot.js` file in your repository with the following contents. See [Configuration](docs/configuration.md) for more information on what behaviors can be built.
 
         on("issues.opened").comment(`


### PR DESCRIPTION
As https://github.com/bkeepers/PRobot/pull/36 got merged, no need to invite probot anymore