### PR TITLE
Include content relative to source repository

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -5,7 +5,7 @@ const log = require('./log');
 
 module.exports = class Configuration {
   static load(context, path, source) {
-    const options = context.toRepo(Object.assign(source, url(path)));
+    const options = context.toRepo(url(path, source));
     log.debug(options, 'Fetching config');
     return context.github.repos.getContent(options).then(data => {
       const config = new Configuration(context, options);
@@ -44,7 +44,7 @@ module.exports = class Configuration {
   }
 
   contents(path) {
-    const options = this.context.toRepo(url(path));
+    const options = this.context.toRepo(url(path, this.source));
     log.debug(options, 'Getting contents');
     return this.context.github.repos.getContent(options).then(data => {
       return new Buffer(data.content, 'base64').toString();

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -4,16 +4,18 @@ const url = require('./util/github-url');
 const log = require('./log');
 
 module.exports = class Configuration {
-  static load(context, path) {
-    const options = context.toRepo(url(path));
+  static load(context, path, source) {
+    const options = context.toRepo(Object.assign(source, url(path)));
     log.debug(options, 'Fetching config');
     return context.github.repos.getContent(options).then(data => {
-      return new Configuration(context).parse(new Buffer(data.content, 'base64').toString());
+      const config = new Configuration(context, options);
+      return config.parse(new Buffer(data.content, 'base64').toString());
     });
   }
 
-  constructor(context) {
+  constructor(context, source) {
     this.context = context;
+    this.source = source || {};
     this.workflows = [];
 
     this.api = {
@@ -30,7 +32,7 @@ module.exports = class Configuration {
   }
 
   include(path) {
-    const load = Configuration.load(this.context, path);
+    const load = Configuration.load(this.context, path, this.source);
 
     this.workflows.push({
       execute() {

--- a/lib/util/github-url.js
+++ b/lib/util/github-url.js
@@ -1,7 +1,7 @@
 const REGEX = /^(?:([\w-]+)\/([\w-]+):)?([^#]*)(?:#(.*))?$/;
 
 // Parses paths in the form of `owner/repo:path/to/file#ref`
-module.exports = function (url) {
+module.exports = function (url, source) {
   const [, owner, repo, path, ref] = url.match(REGEX);
-  return Object.assign({path}, owner && {owner, repo}, ref && {ref});
+  return Object.assign({}, source, {path}, owner && {owner, repo}, ref && {ref});
 };

--- a/test/integration.js
+++ b/test/integration.js
@@ -139,5 +139,29 @@ describe('integration', () => {
         });
       });
     });
+
+    it('gets contents relative to included repository', () => {
+      github.repos.getContent.andCall(params => {
+        if (params.path === 'script-a.js') {
+          return Promise.resolve({
+            content: new Buffer(`
+              on("issues").comment(contents("content.md"));
+            `).toString('base64')
+          });
+        } else {
+          return Promise.resolve({content: ''});
+        }
+      });
+
+      const config = configure('include("other/repo:script-a.js");');
+
+      return config.execute().then(() => {
+        expect(github.repos.getContent).toHaveBeenCalledWith({
+          owner: 'other',
+          repo: 'repo',
+          path: 'content.md'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This updates `include` and `contents` to default to the repository they were included from.

For example, given this `.probot.js`:

```js
include(`other/repo:script/js`)
```

And with `script.js` in `other/repo`:

```js
include('foo.js');           // Defaults to `other/repo:foo.js`
include('that/repo:foo.js'); // Override defaults

on('issues').comment(contents('file.md')); // Defaults to `other/repo:file.md`
on('issues').comment(contents('that/repo:file.md')); // override default
```



Fixes #75 