### PR TITLE
Add `Issue Creation`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,20 @@ Add labels
 .unassign('defunkt');
 ```
 
+### `createIssue`
+
+Create a new issue defined as a JSON Object. The `title` and `body` fields are required.
+
+```js
+.createIssue({"title": "Issue Title", "body": "Issue Body", "assignees": ["bkeepers"], "labels": ["question"]});
+```
+
+The `body` of the issue can be generated from the contents of a template file within the repository by invoking the `contents` function.
+
+```js
+.createIssue({"title": "Issue Title", "body": contents(".github/NEW_ISSUE_TEMPLATE.md"), "assignees": ["bkeepers"], "labels": ["question"]});
+```
+
 ## include
 
 Loads a configuration from another file.
@@ -167,6 +181,21 @@ You can also include configuration from another repository.
 ```js
 include('user/repo:path.js#branch');
 ```
+
+## contents
+
+Retrieves the contents of the repository and passes them to any plugin method.
+
+```js
+on('issues.opened').comment(contents(".github/NEW_ISSUE_TEMPLATE.md"));
+```
+This also supports fetching contents from another repository
+
+```js
+on('issues.opened').comment(contents("atom/configs:.github/NEW_ISSUE_TEMPLATE.md"));
+```
+
+
 
 ---
 

--- a/lib/plugins/issues.js
+++ b/lib/plugins/issues.js
@@ -60,7 +60,7 @@ module.exports = class Issues extends Plugin {
       const titleTemplate = handlebars.compile(content.title)(context.payload);
       const bodyTemplate = handlebars.compile(body)(context.payload);
 
-      return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
+      return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate, assignees: content.assignees, labels: content.labels}));
     });
   }
 };

--- a/lib/plugins/issues.js
+++ b/lib/plugins/issues.js
@@ -55,12 +55,12 @@ module.exports = class Issues extends Plugin {
     return deleteFunction(context.toRepo({id: comment.id}));
   }
 
-  create(context, content) {
-    var lines = content.split('\n');
-    const titleTemplate = handlebars.compile(lines[0])(context.payload);
-    lines.splice(0,1);
-    const bodyTemplate = handlebars.compile(lines.join('\n'))(context.payload);
+  createIssue(context, content) {
+    return Promise.resolve(content.body).then(body => {
+      const titleTemplate = handlebars.compile(content.title)(context.payload);
+      const bodyTemplate = handlebars.compile(body)(context.payload);
 
-    return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
+      return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
+    });
   }
 };

--- a/lib/plugins/issues.js
+++ b/lib/plugins/issues.js
@@ -1,6 +1,7 @@
 const handlebars = require('handlebars');
 const Plugin = require('../plugin');
 
+
 module.exports = class Issues extends Plugin {
   comment(context, content) {
     const template = handlebars.compile(content)(context.payload);
@@ -54,4 +55,14 @@ module.exports = class Issues extends Plugin {
 
     return deleteFunction(context.toRepo({id: comment.id}));
   }
+
+  create(context, content) {
+
+    var lines = content.split('\n');
+    const titleTemplate = handlebars.compile(lines[0])(context.payload);
+    const bodyTemplate = handlebars.compile(lines.splice(0,1)join('\n'))(context.payload);//buf.toString())(context.payload);
+    return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
+
+  }
+  
 };

--- a/lib/plugins/issues.js
+++ b/lib/plugins/issues.js
@@ -1,7 +1,6 @@
 const handlebars = require('handlebars');
 const Plugin = require('../plugin');
 
-
 module.exports = class Issues extends Plugin {
   comment(context, content) {
     const template = handlebars.compile(content)(context.payload);
@@ -57,12 +56,11 @@ module.exports = class Issues extends Plugin {
   }
 
   create(context, content) {
-
     var lines = content.split('\n');
     const titleTemplate = handlebars.compile(lines[0])(context.payload);
-    const bodyTemplate = handlebars.compile(lines.splice(0,1)join('\n'))(context.payload);//buf.toString())(context.payload);
-    return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
+    lines.splice(0,1);
+    const bodyTemplate = handlebars.compile(lines.join('\n'))(context.payload);
 
+    return context.github.issues.create(context.toRepo({title: titleTemplate, body: bodyTemplate}));
   }
-  
 };

--- a/test/plugins/issues.js
+++ b/test/plugins/issues.js
@@ -241,13 +241,15 @@ describe('issues plugin', () => {
   });
 
   describe('createIssue', () => {
-    it('creates an issues', () => {
+    it('creates an issue', () => {
       return this.issues.createIssue(context, {title: 'testing', body: 'body'}).then(() => {
         expect(github.issues.create).toHaveBeenCalledWith({
           owner: 'bkeepers-inc',
           repo: 'test',
           title: 'testing',
-          body: 'body'
+          body: 'body',
+          assignees: undefined,
+          labels: undefined
         });
       });
     });
@@ -258,7 +260,22 @@ describe('issues plugin', () => {
           owner: 'bkeepers-inc',
           repo: 'test',
           title: 'testing',
-          body: 'body'
+          body: 'body',
+          assignees: undefined,
+          labels: undefined
+        });
+      });
+    });
+
+    it('sets optional parameters', () => {
+      return this.issues.createIssue(context, {title: 'testing', body: 'body', assignees: ['bkeepers'], labels: ['hello']}).then(() => {
+        expect(github.issues.create).toHaveBeenCalledWith({
+          owner: 'bkeepers-inc',
+          repo: 'test',
+          title: 'testing',
+          body: 'body',
+          assignees: ['bkeepers'],
+          labels: ['hello']
         });
       });
     });

--- a/test/plugins/issues.js
+++ b/test/plugins/issues.js
@@ -20,7 +20,8 @@ describe('issues plugin', () => {
         addAssigneesToIssue: createSpy(),
         removeAssigneesFromIssue: createSpy(),
         removeLabel: createSpy(),
-        deleteComment: createSpy()
+        deleteComment: createSpy(),
+        create: createSpy()
       },
       repos: {
         deleteCommitComment: createSpy()
@@ -235,6 +236,30 @@ describe('issues plugin', () => {
         owner: 'bkeepers-inc',
         repo: 'test',
         id: 90805181
+      });
+    });
+  });
+
+  describe('createIssue', () => {
+    it('creates an issues', () => {
+      return this.issues.createIssue(context, {title: 'testing', body: 'body'}).then(() => {
+        expect(github.issues.create).toHaveBeenCalledWith({
+          owner: 'bkeepers-inc',
+          repo: 'test',
+          title: 'testing',
+          body: 'body'
+        });
+      });
+    });
+
+    it('resolves body content', () => {
+      return this.issues.createIssue(context, {title: 'testing', body: Promise.resolve('body')}).then(() => {
+        expect(github.issues.create).toHaveBeenCalledWith({
+          owner: 'bkeepers-inc',
+          repo: 'test',
+          title: 'testing',
+          body: 'body'
+        });
       });
     });
   });


### PR DESCRIPTION
This adds a method for creating a new issue based upon a template specified in the config argument. The first line of the template creates the issue title, and the subsequent content makes up the body of the issue. 

## Example:

Where the following line is added to probot.js:

> on('issues.closed')
  .create(contents("IssueTemplate.md"));

And where `IssueTemplate.md` is:

>New Issue Title
>### Here is my test issue template
>
>- [ ] Issue Checklist

The resulting issue is created:
>![screen shot 2017-01-23 at 10 43 03 am](https://cloud.githubusercontent.com/assets/11798972/22215498/d0c7ec94-e158-11e6-827a-3b64501f98fa.png)

## Todo:
- [x] Add testing
- [x] This may be better if refactored to take two arguments in configuration: one for the Title and one for the Body. I had originally tried to pass these in as a JSON object, but I was having trouble getting the body content to resolve properly with handlebars. Pending further conversation, I think I'd like to revisit this approach.