### PR TITLE
Add routing plugin

### DIFF
--- a/lib/plugins/routing.js
+++ b/lib/plugins/routing.js
@@ -1,0 +1,17 @@
+const Plugin = require('../plugin');
+const Configuration = require('../configuration');
+const url = require('../util/github-url');
+
+console.log("WTF?", Configuration, Configuration.load);
+
+module.exports = class Routing extends Plugin {
+  route(context, path) {
+    console.log(Configuration, Configuration.load)
+    return Configuration.load(context, path).then(config => {
+      const parts = url(path);
+      context.event.payload.repository.name = parts.repo;
+      context.event.payload.repository.owner.login = parts.owner;
+      return config.execute(context);
+    });
+  }
+}

--- a/lib/plugins/routing.js
+++ b/lib/plugins/routing.js
@@ -2,11 +2,11 @@ const Plugin = require('../plugin');
 const Configuration = require('../configuration');
 const url = require('../util/github-url');
 
-console.log("WTF?", Configuration, Configuration.load);
+console.log('WTF?', Configuration, Configuration.load);
 
 module.exports = class Routing extends Plugin {
   route(context, path) {
-    console.log(Configuration, Configuration.load)
+    console.log(Configuration, Configuration.load);
     return Configuration.load(context, path).then(config => {
       const parts = url(path);
       context.event.payload.repository.name = parts.repo;
@@ -14,4 +14,4 @@ module.exports = class Routing extends Plugin {
       return config.execute(context);
     });
   }
-}
+};

--- a/lib/plugins/routing.js
+++ b/lib/plugins/routing.js
@@ -2,11 +2,8 @@ const Plugin = require('../plugin');
 const Configuration = require('../configuration');
 const url = require('../util/github-url');
 
-console.log('WTF?', Configuration, Configuration.load);
-
 module.exports = class Routing extends Plugin {
   route(context, path) {
-    console.log(Configuration, Configuration.load);
     return Configuration.load(context, path).then(config => {
       const parts = url(path);
       context.event.payload.repository.name = parts.repo;

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -11,11 +11,11 @@ class Robot {
   receive(event) {
     log.trace('webhook', event);
 
-    if(!event.payload.repository) {
+    if (!event.payload.repository) {
       event.payload.repository = {
         name: 'probot-scripts',
         owner: event.payload.organization
-      }
+      };
     }
 
     installations.auth(event.payload.installation.id).then(github => {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -11,14 +11,19 @@ class Robot {
   receive(event) {
     log.trace('webhook', event);
 
-    if (event.payload.repository) {
-      installations.auth(event.payload.installation.id).then(github => {
-        const context = new Context(github, event);
-        Configuration.load(context, '.probot.js').then(config => {
-          return config.execute();
-        });
-      });
+    if(!event.payload.repository) {
+      event.payload.repository = {
+        name: 'probot-scripts',
+        owner: event.payload.organization
+      }
     }
+
+    installations.auth(event.payload.installation.id).then(github => {
+      const context = new Context(github, event);
+      Configuration.load(context, '.probot.js').then(config => {
+        return config.execute();
+      });
+    });
   }
 }
 

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -1,7 +1,9 @@
 const Issues = require('./plugins/issues');
+const Routing = require('./plugins/routing');
 
 const plugins = [
-  new Issues()
+  new Issues(),
+  new Routing()
 ];
 
 module.exports = class Workflow {

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -1,11 +1,3 @@
-const Issues = require('./plugins/issues');
-const Routing = require('./plugins/routing');
-
-const plugins = [
-  new Issues(),
-  new Routing()
-];
-
 module.exports = class Workflow {
   constructor(events) {
     this.stack = [];
@@ -13,8 +5,14 @@ module.exports = class Workflow {
     this.filterFn = () => true;
     this.api = {};
 
+    const plugins = [
+      require('./plugins/issues'),
+      require('./plugins/routing')
+    ];
+
     // Define a new function in the API for each plugin method
-    for (const plugin of plugins) {
+    for (const Plugin of plugins) {
+      const plugin = new Plugin();
       for (const method of plugin.api) {
         this.api[method] = this.proxy(plugin[method]).bind(this);
       }


### PR DESCRIPTION
This plugin decouples robot.js from a repository, such that if an event payload doesn't contain a repository, it will default to a repo in the org called `probot-scripts`. From there, a config file can point to different repositories where further actions can be performed. 

Currently, there is a bug importing `configuration.js` into `routing.js`, which still needs to be resolved.