### PR TITLE
Make filter into a plugin

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,7 +36,7 @@ on('issues.labeled')
 
 ```js
 on('issues.opened', 'pull_request.opened')
-  .filter.firstTimeContributor() // plugins could implement conditions like this
+  .ifFirstTimeContributor() // plugins could implement conditions like this
   .comment(contents('.github/NEW_CONTRIBUTOR_TEMPLATE.md'));
 ```
 
@@ -53,7 +53,7 @@ on('pull_request.opened')
 ```js
 on('issues.opened')
   .filter((event) => event.issue.body.match(/^$/))
-  .comment('Hey @{{ user.login }}, you didn't include a description of the problem, so we're closing this issue.');
+  .comment("Hey @{{ user.login }}, you didn't include a description of the problem, so we're closing this issue.");
 ```
 
 ### @mention watchers when label added

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -26,9 +26,9 @@ module.exports = class Configuration {
   }
 
   on(...events) {
-    const workflow = new Workflow(events);
+    const workflow = new Workflow();
     this.workflows.push(workflow);
-    return workflow.api;
+    return workflow.api.on(...events);
   }
 
   include(path) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -5,6 +5,10 @@ module.exports = class Context {
     this.payload = event.payload;
   }
 
+  halt() {
+    return Promise.reject(new Error('halted'));
+  }
+
   toRepo(object) {
     const repo = this.payload.repository;
 

--- a/lib/plugins/filter.js
+++ b/lib/plugins/filter.js
@@ -15,10 +15,10 @@ module.exports = class Filter extends Plugin {
   }
 
   on(context, ...events) {
+    const event = context.event;
     const res = events.find(e => {
       const [name, action] = e.split('.');
-      return name === context.event.event &&
-        (!action || action === context.event.payload.action);
+      return name === event.event && (!action || action === event.payload.action);
     });
 
     return res ? Promise.resolve(res) : this.halt();

--- a/lib/plugins/filter.js
+++ b/lib/plugins/filter.js
@@ -1,13 +1,9 @@
 const Plugin = require('../plugin');
 
-function halt() {
-  return Promise.reject(new Error('halted'));
-}
-
 module.exports = class Filter extends Plugin {
   filter(context, fn) {
     const result = fn(context.event, context);
-    return result === false ? halt() : result;
+    return result === false ? context.halt() : result;
   }
 
   then(context, fn) {
@@ -21,6 +17,6 @@ module.exports = class Filter extends Plugin {
       return name === event.event && (!action || action === event.payload.action);
     });
 
-    return res ? Promise.resolve(res) : halt();
+    return res ? Promise.resolve(res) : context.halt();
   }
 };

--- a/lib/plugins/filter.js
+++ b/lib/plugins/filter.js
@@ -1,0 +1,26 @@
+const Plugin = require('../plugin');
+
+module.exports = class Filter extends Plugin {
+  filter(context, fn) {
+    const result = fn(context.event, context);
+    return result === false ? this.halt() : result;
+  }
+
+  then(context, fn) {
+    return fn(context.event, context);
+  }
+
+  halt() {
+    return Promise.reject(new Error('halted'));
+  }
+
+  on(context, ...events) {
+    const res = events.find(e => {
+      const [name, action] = e.split('.');
+      return name === context.event.event &&
+        (!action || action === context.event.payload.action);
+    });
+
+    return res ? Promise.resolve(res) : this.halt();
+  }
+};

--- a/lib/plugins/filter.js
+++ b/lib/plugins/filter.js
@@ -1,17 +1,17 @@
 const Plugin = require('../plugin');
 
+function halt() {
+  return Promise.reject(new Error('halted'));
+}
+
 module.exports = class Filter extends Plugin {
   filter(context, fn) {
     const result = fn(context.event, context);
-    return result === false ? this.halt() : result;
+    return result === false ? halt() : result;
   }
 
   then(context, fn) {
     return fn(context.event, context);
-  }
-
-  halt() {
-    return Promise.reject(new Error('halted'));
   }
 
   on(context, ...events) {
@@ -21,6 +21,6 @@ module.exports = class Filter extends Plugin {
       return name === event.event && (!action || action === event.payload.action);
     });
 
-    return res ? Promise.resolve(res) : this.halt();
+    return res ? Promise.resolve(res) : halt();
   }
 };

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -1,14 +1,14 @@
+const Filter = require('./plugins/filter');
 const Issues = require('./plugins/issues');
 
-const plugins = [
+const defaultPlugins = [
+  new Filter(),
   new Issues()
 ];
 
 module.exports = class Workflow {
-  constructor(events) {
+  constructor(plugins = defaultPlugins) {
     this.stack = [];
-    this.events = events;
-    this.filterFn = () => true;
     this.api = {};
 
     // Define a new function in the API for each plugin method
@@ -17,20 +17,6 @@ module.exports = class Workflow {
         this.api[method] = this.proxy(plugin[method]).bind(this);
       }
     }
-
-    this.api.filter = this.filter.bind(this);
-  }
-
-  filter(fn) {
-    this.filterFn = fn;
-    return this.api;
-  }
-
-  matches(event) {
-    return this.events.find(e => {
-      const [name, action] = e.split('.');
-      return name === event.event && (!action || action === event.payload.action);
-    }) && this.filterFn(event);
   }
 
   proxy(fn) {
@@ -38,7 +24,7 @@ module.exports = class Workflow {
       // Push new function on the stack that calls the plugin method with a context.
       this.stack.push(context => {
         // Resolve all args before passing to plugin
-        Promise.all(args).then(args => fn(context, ...args));
+        return Promise.all(args).then(args => fn(context, ...args));
       });
 
       // Return the API to allow methods to be chained.
@@ -47,11 +33,9 @@ module.exports = class Workflow {
   }
 
   execute(context) {
-    if (this.matches(context.event)) {
-      // Reduce the stack to a chain of promises, each called with the given context
-      return this.stack.reduce((promise, func) => {
-        return promise.then(func.bind(func, context));
-      }, Promise.resolve());
-    }
+    // Reduce the stack to a chain of promises, each called with the given context
+    return this.stack.reduce((promise, func) => {
+      return promise.then(func.bind(func, context));
+    }, Promise.resolve());
   }
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
     "envs": [
       "node",
       "mocha"
+    ],
+    "overrides": [
+      {
+        "files": "test/**/*.js",
+        "rules": {
+          "max-nested-callbacks": "off"
+        }
+      }
     ]
   },
   "engines": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,167 +1,168 @@
-// const expect = require('expect');
-// const Configuration = require('../lib/configuration');
-// const Context = require('../lib/context');
-// const payload = require('./fixtures/webhook/comment.created.json');
-//
-// const createSpy = expect.createSpy;
-//
-// describe('integration', () => {
-//   const event = {event: 'issues', payload};
-//   let context;
-//   let github;
-//
-//   beforeEach(() => {
-//     github = {
-//       issues: {
-//         createComment: createSpy().andReturn(Promise.resolve()),
-//         edit: createSpy().andReturn(Promise.resolve())
-//       },
-//       repos: {
-//         getContent: createSpy()
-//       }
-//     };
-//
-//     context = new Context(github, event);
-//   });
-//
-//   function configure(content) {
-//     return new Configuration(context).parse(content);
-//   }
-//
-//   describe('reply to new issue with a comment', () => {
-//     it('posts a coment', () => {
-//       const config = configure('on("issues").comment("Hello World!")');
-//       return config.execute(context).then(() => {
-//         expect(github.issues.createComment).toHaveBeenCalled();
-//       });
-//     });
-//   });
-//
-//   describe('on an event with a different action', () => {
-//     it('does not perform behavior', () => {
-//       const config = configure('on("issues.labeled").comment("Hello World!")');
-//
-//       return config.execute(context).then(() => {
-//         expect(github.issues.createComment).toNotHaveBeenCalled();
-//       });
-//     });
-//   });
-//
-//   describe('filter', () => {
-//     beforeEach(() => {
-//       const labeled = require('./fixtures/webhook/issues.labeled.json');
-//
-//       const event = {event: 'issues', payload: labeled, issue: {}};
-//       context = new Context(github, event);
-//     });
-//
-//     it('calls action when condition matches', () => {
-//       const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
-//       return config.execute(context).then(() => {
-//         expect(github.issues.edit).toHaveBeenCalled();
-//       });
-//     });
-//
-//     it('does not call action when conditions do not match', () => {
-//       const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
-//       return config.execute(context).then(() => {
-//         expect(github.issues.edit).toNotHaveBeenCalled();
-//       });
-//     });
-//   });
-//
-//   describe('include', () => {
-//     let content;
-//
-//     beforeEach(() => {
-//       content = require('./fixtures/content/probot.json');
-//
-//       content.content = new Buffer('on("issues").comment("Hello!");').toString('base64');
-//       github.repos.getContent.andReturn(Promise.resolve(content));
-//
-//       context = new Context(github, event);
-//     });
-//
-//     it('includes a file in the local repository', () => {
-//       configure('include(".github/triage.js");');
-//       expect(github.repos.getContent).toHaveBeenCalledWith({
-//         owner: 'bkeepers-inc',
-//         repo: 'test',
-//         path: '.github/triage.js'
-//       });
-//     });
-//
-//     it('executes included rules', done => {
-//       configure('include(".github/triage.js");').execute().then(() => {
-//         expect(github.issues.createComment).toHaveBeenCalled();
-//         done();
-//       });
-//     });
-//
-//     it('includes files relative to included repository', () => {
-//       github.repos.getContent.andCall(params => {
-//         if (params.path === 'script-a.js') {
-//           return Promise.resolve({
-//             content: new Buffer('include("script-b.js")').toString('base64')
-//           });
-//         } else {
-//           return Promise.resolve({content: ''});
-//         }
-//       });
-//
-//       const config = configure('include("other/repo:script-a.js");');
-//
-//       return config.execute().then(() => {
-//         expect(github.repos.getContent).toHaveBeenCalledWith({
-//           owner: 'other',
-//           repo: 'repo',
-//           path: 'script-b.js'
-//         });
-//       });
-//     });
-//   });
-//
-//   describe('contents', () => {
-//     it('gets content from repo', () => {
-//       const content = {content: new Buffer('file contents').toString('base64')};
-//       github.repos.getContent.andReturn(Promise.resolve(content));
-//
-//       const config = configure(`
-//         on("issues").comment(contents(".github/ISSUE_REPLY_TEMPLATE"));
-//       `);
-//
-//       return config.execute().then(() => {
-//         expect(github.issues.createComment).toHaveBeenCalledWith({
-//           owner: 'bkeepers-inc',
-//           repo: 'test',
-//           number: event.payload.issue.number,
-//           body: 'file contents'
-//         });
-//       });
-//     });
-//
-//     it('gets contents relative to included repository', () => {
-//       github.repos.getContent.andCall(params => {
-//         if (params.path === 'script-a.js') {
-//           return Promise.resolve({
-//             content: new Buffer(`
-//               on("issues").comment(contents("content.md"));
-//             `).toString('base64')
-//           });
-//         } else {
-//           return Promise.resolve({content: ''});
-//         }
-//       });
-//
-//       const config = configure('include("other/repo:script-a.js");');
-//
-//       return config.execute().then(() => {
-//         expect(github.repos.getContent).toHaveBeenCalledWith({
-//           owner: 'other',
-//           repo: 'repo',
-//           path: 'content.md'
-//         });
-//       });
-//     });
-//   });
-// });
+const expect = require('expect');
+const Configuration = require('../lib/configuration');
+const Context = require('../lib/context');
+const payload = require('./fixtures/webhook/comment.created.json');
+
+const createSpy = expect.createSpy;
+
+describe('integration', () => {
+  const event = {event: 'issues', payload};
+  let context;
+  let github;
+
+  beforeEach(() => {
+    github = {
+      issues: {
+        createComment: createSpy().andReturn(Promise.resolve()),
+        edit: createSpy().andReturn(Promise.resolve())
+      },
+      repos: {
+        getContent: createSpy()
+      }
+    };
+
+    context = new Context(github, event);
+  });
+
+  function configure(content) {
+    return new Configuration(context).parse(content);
+  }
+
+  describe('reply to new issue with a comment', () => {
+    it('posts a coment', () => {
+      const config = configure('on("issues").comment("Hello World!")');
+      return config.execute(context).then(() => {
+        expect(github.issues.createComment).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('on an event with a different action', () => {
+    it('does not perform behavior', () => {
+      const config = configure('on("issues.labeled").comment("Hello World!")');
+
+      return config.execute(context).catch(() => {
+        expect(github.issues.createComment).toNotHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('filter', () => {
+    beforeEach(() => {
+      const labeled = require('./fixtures/webhook/issues.labeled.json');
+
+      const event = {event: 'issues', payload: labeled, issue: {}};
+      context = new Context(github, event);
+    });
+
+    it('calls action when condition matches', () => {
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
+      return config.execute(context).then(() => {
+        expect(github.issues.edit).toHaveBeenCalled();
+      });
+    });
+
+    it('does not call action when conditions do not match', () => {
+      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
+
+      return config.execute(context).catch(() => {
+        expect(github.issues.edit).toNotHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('include', () => {
+    let content;
+
+    beforeEach(() => {
+      content = require('./fixtures/content/probot.json');
+
+      content.content = new Buffer('on("issues").comment("Hello!");').toString('base64');
+      github.repos.getContent.andReturn(Promise.resolve(content));
+
+      context = new Context(github, event);
+    });
+
+    it('includes a file in the local repository', () => {
+      configure('include(".github/triage.js");');
+      expect(github.repos.getContent).toHaveBeenCalledWith({
+        owner: 'bkeepers-inc',
+        repo: 'test',
+        path: '.github/triage.js'
+      });
+    });
+
+    it('executes included rules', done => {
+      configure('include(".github/triage.js");').execute().then(() => {
+        expect(github.issues.createComment).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('includes files relative to included repository', () => {
+      github.repos.getContent.andCall(params => {
+        if (params.path === 'script-a.js') {
+          return Promise.resolve({
+            content: new Buffer('include("script-b.js")').toString('base64')
+          });
+        } else {
+          return Promise.resolve({content: ''});
+        }
+      });
+
+      const config = configure('include("other/repo:script-a.js");');
+
+      return config.execute().then(() => {
+        expect(github.repos.getContent).toHaveBeenCalledWith({
+          owner: 'other',
+          repo: 'repo',
+          path: 'script-b.js'
+        });
+      });
+    });
+  });
+
+  describe('contents', () => {
+    it('gets content from repo', () => {
+      const content = {content: new Buffer('file contents').toString('base64')};
+      github.repos.getContent.andReturn(Promise.resolve(content));
+
+      const config = configure(`
+        on("issues").comment(contents(".github/ISSUE_REPLY_TEMPLATE"));
+      `);
+
+      return config.execute().then(() => {
+        expect(github.issues.createComment).toHaveBeenCalledWith({
+          owner: 'bkeepers-inc',
+          repo: 'test',
+          number: event.payload.issue.number,
+          body: 'file contents'
+        });
+      });
+    });
+
+    it('gets contents relative to included repository', () => {
+      github.repos.getContent.andCall(params => {
+        if (params.path === 'script-a.js') {
+          return Promise.resolve({
+            content: new Buffer(`
+              on("issues").comment(contents("content.md"));
+            `).toString('base64')
+          });
+        } else {
+          return Promise.resolve({content: ''});
+        }
+      });
+
+      const config = configure('include("other/repo:script-a.js");');
+
+      return config.execute().then(() => {
+        expect(github.repos.getContent).toHaveBeenCalledWith({
+          owner: 'other',
+          repo: 'repo',
+          path: 'content.md'
+        });
+      });
+    });
+  });
+});

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,167 +1,167 @@
-const expect = require('expect');
-const Configuration = require('../lib/configuration');
-const Context = require('../lib/context');
-const payload = require('./fixtures/webhook/comment.created.json');
-
-const createSpy = expect.createSpy;
-
-describe('integration', () => {
-  const event = {event: 'issues', payload};
-  let context;
-  let github;
-
-  beforeEach(() => {
-    github = {
-      issues: {
-        createComment: createSpy().andReturn(Promise.resolve()),
-        edit: createSpy().andReturn(Promise.resolve())
-      },
-      repos: {
-        getContent: createSpy()
-      }
-    };
-
-    context = new Context(github, event);
-  });
-
-  function configure(content) {
-    return new Configuration(context).parse(content);
-  }
-
-  describe('reply to new issue with a comment', () => {
-    it('posts a coment', () => {
-      const config = configure('on("issues").comment("Hello World!")');
-      return config.execute(context).then(() => {
-        expect(github.issues.createComment).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('on an event with a different action', () => {
-    it('does not perform behavior', () => {
-      const config = configure('on("issues.labeled").comment("Hello World!")');
-
-      return config.execute(context).then(() => {
-        expect(github.issues.createComment).toNotHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('filter', () => {
-    beforeEach(() => {
-      const labeled = require('./fixtures/webhook/issues.labeled.json');
-
-      const event = {event: 'issues', payload: labeled, issue: {}};
-      context = new Context(github, event);
-    });
-
-    it('calls action when condition matches', () => {
-      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
-      return config.execute(context).then(() => {
-        expect(github.issues.edit).toHaveBeenCalled();
-      });
-    });
-
-    it('does not call action when conditions do not match', () => {
-      const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
-      return config.execute(context).then(() => {
-        expect(github.issues.edit).toNotHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('include', () => {
-    let content;
-
-    beforeEach(() => {
-      content = require('./fixtures/content/probot.json');
-
-      content.content = new Buffer('on("issues").comment("Hello!");').toString('base64');
-      github.repos.getContent.andReturn(Promise.resolve(content));
-
-      context = new Context(github, event);
-    });
-
-    it('includes a file in the local repository', () => {
-      configure('include(".github/triage.js");');
-      expect(github.repos.getContent).toHaveBeenCalledWith({
-        owner: 'bkeepers-inc',
-        repo: 'test',
-        path: '.github/triage.js'
-      });
-    });
-
-    it('executes included rules', done => {
-      configure('include(".github/triage.js");').execute().then(() => {
-        expect(github.issues.createComment).toHaveBeenCalled();
-        done();
-      });
-    });
-
-    it('includes files relative to included repository', () => {
-      github.repos.getContent.andCall(params => {
-        if (params.path === 'script-a.js') {
-          return Promise.resolve({
-            content: new Buffer('include("script-b.js")').toString('base64')
-          });
-        } else {
-          return Promise.resolve({content: ''});
-        }
-      });
-
-      const config = configure('include("other/repo:script-a.js");');
-
-      return config.execute().then(() => {
-        expect(github.repos.getContent).toHaveBeenCalledWith({
-          owner: 'other',
-          repo: 'repo',
-          path: 'script-b.js'
-        });
-      });
-    });
-  });
-
-  describe('contents', () => {
-    it('gets content from repo', () => {
-      const content = {content: new Buffer('file contents').toString('base64')};
-      github.repos.getContent.andReturn(Promise.resolve(content));
-
-      const config = configure(`
-        on("issues").comment(contents(".github/ISSUE_REPLY_TEMPLATE"));
-      `);
-
-      return config.execute().then(() => {
-        expect(github.issues.createComment).toHaveBeenCalledWith({
-          owner: 'bkeepers-inc',
-          repo: 'test',
-          number: event.payload.issue.number,
-          body: 'file contents'
-        });
-      });
-    });
-
-    it('gets contents relative to included repository', () => {
-      github.repos.getContent.andCall(params => {
-        if (params.path === 'script-a.js') {
-          return Promise.resolve({
-            content: new Buffer(`
-              on("issues").comment(contents("content.md"));
-            `).toString('base64')
-          });
-        } else {
-          return Promise.resolve({content: ''});
-        }
-      });
-
-      const config = configure('include("other/repo:script-a.js");');
-
-      return config.execute().then(() => {
-        expect(github.repos.getContent).toHaveBeenCalledWith({
-          owner: 'other',
-          repo: 'repo',
-          path: 'content.md'
-        });
-      });
-    });
-  });
-});
+// const expect = require('expect');
+// const Configuration = require('../lib/configuration');
+// const Context = require('../lib/context');
+// const payload = require('./fixtures/webhook/comment.created.json');
+//
+// const createSpy = expect.createSpy;
+//
+// describe('integration', () => {
+//   const event = {event: 'issues', payload};
+//   let context;
+//   let github;
+//
+//   beforeEach(() => {
+//     github = {
+//       issues: {
+//         createComment: createSpy().andReturn(Promise.resolve()),
+//         edit: createSpy().andReturn(Promise.resolve())
+//       },
+//       repos: {
+//         getContent: createSpy()
+//       }
+//     };
+//
+//     context = new Context(github, event);
+//   });
+//
+//   function configure(content) {
+//     return new Configuration(context).parse(content);
+//   }
+//
+//   describe('reply to new issue with a comment', () => {
+//     it('posts a coment', () => {
+//       const config = configure('on("issues").comment("Hello World!")');
+//       return config.execute(context).then(() => {
+//         expect(github.issues.createComment).toHaveBeenCalled();
+//       });
+//     });
+//   });
+//
+//   describe('on an event with a different action', () => {
+//     it('does not perform behavior', () => {
+//       const config = configure('on("issues.labeled").comment("Hello World!")');
+//
+//       return config.execute(context).then(() => {
+//         expect(github.issues.createComment).toNotHaveBeenCalled();
+//       });
+//     });
+//   });
+//
+//   describe('filter', () => {
+//     beforeEach(() => {
+//       const labeled = require('./fixtures/webhook/issues.labeled.json');
+//
+//       const event = {event: 'issues', payload: labeled, issue: {}};
+//       context = new Context(github, event);
+//     });
+//
+//     it('calls action when condition matches', () => {
+//       const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "bug").close()');
+//       return config.execute(context).then(() => {
+//         expect(github.issues.edit).toHaveBeenCalled();
+//       });
+//     });
+//
+//     it('does not call action when conditions do not match', () => {
+//       const config = configure('on("issues.labeled").filter((e) => e.payload.label.name == "foobar").close()');
+//       return config.execute(context).then(() => {
+//         expect(github.issues.edit).toNotHaveBeenCalled();
+//       });
+//     });
+//   });
+//
+//   describe('include', () => {
+//     let content;
+//
+//     beforeEach(() => {
+//       content = require('./fixtures/content/probot.json');
+//
+//       content.content = new Buffer('on("issues").comment("Hello!");').toString('base64');
+//       github.repos.getContent.andReturn(Promise.resolve(content));
+//
+//       context = new Context(github, event);
+//     });
+//
+//     it('includes a file in the local repository', () => {
+//       configure('include(".github/triage.js");');
+//       expect(github.repos.getContent).toHaveBeenCalledWith({
+//         owner: 'bkeepers-inc',
+//         repo: 'test',
+//         path: '.github/triage.js'
+//       });
+//     });
+//
+//     it('executes included rules', done => {
+//       configure('include(".github/triage.js");').execute().then(() => {
+//         expect(github.issues.createComment).toHaveBeenCalled();
+//         done();
+//       });
+//     });
+//
+//     it('includes files relative to included repository', () => {
+//       github.repos.getContent.andCall(params => {
+//         if (params.path === 'script-a.js') {
+//           return Promise.resolve({
+//             content: new Buffer('include("script-b.js")').toString('base64')
+//           });
+//         } else {
+//           return Promise.resolve({content: ''});
+//         }
+//       });
+//
+//       const config = configure('include("other/repo:script-a.js");');
+//
+//       return config.execute().then(() => {
+//         expect(github.repos.getContent).toHaveBeenCalledWith({
+//           owner: 'other',
+//           repo: 'repo',
+//           path: 'script-b.js'
+//         });
+//       });
+//     });
+//   });
+//
+//   describe('contents', () => {
+//     it('gets content from repo', () => {
+//       const content = {content: new Buffer('file contents').toString('base64')};
+//       github.repos.getContent.andReturn(Promise.resolve(content));
+//
+//       const config = configure(`
+//         on("issues").comment(contents(".github/ISSUE_REPLY_TEMPLATE"));
+//       `);
+//
+//       return config.execute().then(() => {
+//         expect(github.issues.createComment).toHaveBeenCalledWith({
+//           owner: 'bkeepers-inc',
+//           repo: 'test',
+//           number: event.payload.issue.number,
+//           body: 'file contents'
+//         });
+//       });
+//     });
+//
+//     it('gets contents relative to included repository', () => {
+//       github.repos.getContent.andCall(params => {
+//         if (params.path === 'script-a.js') {
+//           return Promise.resolve({
+//             content: new Buffer(`
+//               on("issues").comment(contents("content.md"));
+//             `).toString('base64')
+//           });
+//         } else {
+//           return Promise.resolve({content: ''});
+//         }
+//       });
+//
+//       const config = configure('include("other/repo:script-a.js");');
+//
+//       return config.execute().then(() => {
+//         expect(github.repos.getContent).toHaveBeenCalledWith({
+//           owner: 'other',
+//           repo: 'repo',
+//           path: 'content.md'
+//         });
+//       });
+//     });
+//   });
+// });

--- a/test/plugins/filter.js
+++ b/test/plugins/filter.js
@@ -5,7 +5,10 @@ const createSpy = expect.createSpy;
 
 describe('filter plugin', () => {
   const event = {};
-  const context = {event};
+  const context = {
+    event,
+    halt: createSpy().andReturn(Promise.reject(new Error('halted')))
+  };
 
   let filter;
 

--- a/test/plugins/filter.js
+++ b/test/plugins/filter.js
@@ -50,4 +50,78 @@ describe('filter plugin', () => {
       expect(filter.then(context, fn)).toBe('bazinga!');
     });
   });
+
+  describe('on', () => {
+    describe('matching only the event name', () => {
+      it('matches on a single event', () => {
+        event.event = 'issues';
+
+        return filter.on(context, 'issues').then(result => {
+          expect(result).toEqual('issues');
+        });
+      });
+
+      it('fails to match on a single event', () => {
+        event.event = 'issues';
+
+        return filter.on(context, 'foo').catch(err => {
+          expect(err.message).toBe('halted');
+        });
+      });
+
+      it('matches any of the event names', () => {
+        event.event = 'foo';
+
+        return filter.on(context, 'issues', 'foo').then(result => {
+          expect(result).toEqual('foo');
+        });
+      });
+
+      it('fails to match if none of the event names match', () => {
+        event.event = 'bar';
+
+        return filter.on(context, 'issues', 'foo').catch(err => {
+          expect(err.message).toBe('halted');
+        });
+      });
+    });
+
+    describe('matching the event and action', () => {
+      it('matches on a single event', () => {
+        event.event = 'issues';
+        event.payload = {action: 'opened'};
+
+        return filter.on(context, 'issues.opened').then(result => {
+          expect(result).toBe('issues.opened');
+        });
+      });
+
+      it('fails to match on a single event', () => {
+        event.event = 'issues';
+        event.payload = {action: 'foo'};
+
+        return filter.on(context, 'issues.opened').catch(err => {
+          expect(err.message).toBe('halted');
+        });
+      });
+
+      it('matches any of the event descriptors', () => {
+        event.event = 'issues';
+        event.payload = {action: 'closed'};
+
+        return filter.on(context, 'issues.opened', 'issues.closed').then(result => {
+          expect(result).toBe('issues.closed');
+        });
+      });
+
+      it('fails to match if none of the event descriptors match', () => {
+        event.event = 'issues';
+        event.payload = {action: 'foo'};
+
+        return filter.on(context, 'issues.opened', 'issues.closed').catch(err => {
+          expect(err.message).toBe('halted');
+        });
+      });
+    });
+  });
 });

--- a/test/plugins/filter.js
+++ b/test/plugins/filter.js
@@ -1,0 +1,53 @@
+const expect = require('expect');
+const Filter = require('../../lib/plugins/filter');
+
+const createSpy = expect.createSpy;
+
+describe('filter plugin', () => {
+  const event = {};
+  const context = {event};
+
+  let filter;
+
+  before(() => {
+    filter = new Filter();
+  });
+
+  describe('filter', () => {
+    it('passes the event and context objects to the supplied function', () => {
+      const fn = createSpy();
+      filter.filter(context, fn);
+
+      expect(fn).toHaveBeenCalledWith(event, context);
+    });
+
+    it('returns true if the function does', () => {
+      const fn = createSpy().andReturn(true);
+
+      expect(filter.filter(context, fn)).toBe(true);
+    });
+
+    it('returns a rejected promise if the function returns false', () => {
+      const fn = createSpy().andReturn(false);
+
+      return filter.filter(context, fn).catch(err => {
+        expect(err.message).toEqual('halted');
+      });
+    });
+  });
+
+  describe('then', () => {
+    it('passes the event and context objects to the supplied function', () => {
+      const fn = createSpy();
+      filter.filter(context, fn);
+
+      expect(fn).toHaveBeenCalledWith(event, context);
+    });
+
+    it('returns whatever the function does', () => {
+      const fn = createSpy().andReturn('bazinga!');
+
+      expect(filter.then(context, fn)).toBe('bazinga!');
+    });
+  });
+});

--- a/test/workflow.js
+++ b/test/workflow.js
@@ -78,12 +78,21 @@ describe('Workflow', () => {
       });
     });
 
+    it('calls each chained function even if a falsy value is returned', () => {
+      workflow.api.doSomething('bar', 'baz').returnUndefined().doSomething('baz', 'quux');
+
+      return workflow.execute(context).then(() => {
+        expect(context.bar).toBe('baz');
+        expect(context.baz).toBe('quux');
+      });
+    });
+
     it('calls each chained function until a promise is rejected', () => {
       workflow.api.doSomething('bar', 'baz').rejectPromise().doSomething('baz', 'quux');
 
       return workflow.execute(context).then(() => {
         throw new Error('Should not happen');
-      }).catch(err => {
+      }, err => {
         expect(err.message).toBe('HALT AND CATCH FIRE!!!');
         expect(context.bar).toBe('baz');
         expect(context.baz).toNotExist();
@@ -95,7 +104,7 @@ describe('Workflow', () => {
 
       return workflow.execute(context).then(() => {
         throw new Error('Should not happen');
-      }).catch(err => {
+      }, err => {
         expect(err.message).toBe('Nothing to see here, move along');
         expect(context.bar).toBe('baz');
         expect(context.baz).toNotExist();

--- a/test/workflow.js
+++ b/test/workflow.js
@@ -25,10 +25,11 @@ class TestPlugin extends Plugin {
 }
 
 describe('Workflow', () => {
-  const context = {};
+  let context;
   let workflow;
 
   beforeEach(() => {
+    context = {};
     workflow = new Workflow([new TestPlugin()]);
   });
 

--- a/test/workflow.js
+++ b/test/workflow.js
@@ -1,42 +1,105 @@
 const expect = require('expect');
+const Plugin = require('../lib/plugin');
 const Workflow = require('../lib/workflow');
 
+class TestPlugin extends Plugin {
+  doSomething(context, name, value) {
+    context[name] = value;
+  }
+
+  rejectPromise() {
+    return Promise.reject(new Error('HALT AND CATCH FIRE!!!'));
+  }
+
+  returnUndefined() {
+    return undefined;
+  }
+
+  test() {
+    return 'passed!';
+  }
+
+  throwError() {
+    throw new Error('Nothing to see here, move along');
+  }
+}
+
 describe('Workflow', () => {
-  describe('matches', () => {
-    it('is truthy for matching event', () => {
-      const workflow = new Workflow(['issues']);
-      expect(workflow.matches({event: 'issues', payload: {}})).toBeTruthy();
+  const context = {};
+  let workflow;
+
+  beforeEach(() => {
+    workflow = new Workflow([new TestPlugin()]);
+  });
+
+  describe('construction', () => {
+    it('adds the plugins distinctiveness to its own', () => {
+      expect(workflow.api.test).toExist();
     });
 
-    it('is truthy for multiple events', () => {
-      const workflow = new Workflow(['issues', 'pull_request']);
-      expect(workflow.matches({event: 'pull_request', payload: {}})).toBeTruthy();
+    it('returns a reference to the API for chaining when the test function is called', () => {
+      const api = workflow.api.test();
+
+      expect(api).toBe(workflow.api);
+    });
+  });
+
+  describe('execution', () => {
+    it('returns a resolved promise with the ultimate value when everything works', () => {
+      workflow.api.test();
+
+      return workflow.execute(context).then(result => {
+        expect(result).toBe('passed!');
+      });
     });
 
-    it('is truthy for event with action', () => {
-      const workflow = new Workflow(['issues.opened']);
-      expect(
-        workflow.matches({event: 'issues', payload: {action: 'opened'}})
-      ).toBeTruthy();
+    it('returns a rejected promise when a promise is rejected', () => {
+      workflow.api.rejectPromise();
+
+      return workflow.execute(context).catch(err => {
+        expect(err.message).toBe('HALT AND CATCH FIRE!!!');
+      });
     });
 
-    it('is truthy for multiple events with action', () => {
-      const workflow = new Workflow(['issues.opened', 'issues.labeled']);
-      expect(
-        workflow.matches({event: 'issues', payload: {action: 'labeled'}})
-      ).toBeTruthy();
+    it('returns a rejected promise when an error is thrown', () => {
+      workflow.api.throwError();
+
+      return workflow.execute(context).catch(err => {
+        expect(err.message).toBe('Nothing to see here, move along');
+      });
     });
 
-    it('is falsy for different event', () => {
-      const workflow = new Workflow(['issues']);
-      expect(workflow.matches({event: 'pull_request', payload: {}})).toBeFalsy();
+    it('calls each chained function when things succeed', () => {
+      workflow.api.doSomething('bar', 'baz').doSomething('baz', 'quux');
+
+      return workflow.execute(context).then(() => {
+        expect(context.bar).toBe('baz');
+        expect(context.baz).toBe('quux');
+      });
     });
 
-    it('is falsy for different action', () => {
-      const workflow = new Workflow(['issues.opened']);
-      expect(
-        workflow.matches({event: 'issues', payload: {action: 'labeled'}})
-      ).toBeFalsy();
+    it('calls each chained function until a promise is rejected', () => {
+      workflow.api.doSomething('bar', 'baz').rejectPromise().doSomething('baz', 'quux');
+
+      return workflow.execute(context).then(() => {
+        throw new Error('Should not happen');
+      }).catch(err => {
+        expect(err.message).toBe('HALT AND CATCH FIRE!!!');
+        expect(context.bar).toBe('baz');
+        expect(context.baz).toNotExist();
+      });
+    });
+
+    it('calls each chained function until an error is thrown', () => {
+      workflow.api.doSomething('bar', 'baz').throwError().doSomething('baz', 'quux');
+
+      return workflow.execute(context).then(() => {
+        throw new Error('Should not happen');
+      }).catch(err => {
+        expect(err.message).toBe('Nothing to see here, move along');
+        expect(context.bar).toBe('baz');
+        expect(context.baz).toNotExist();
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #81 

* Moves all conditional logic to `Filter` plugin
* Adds a _lot_ of specs
* Pass both `context` and `event` to filter functions to allow access to the GitHub API
